### PR TITLE
Do not expect indentation for set directives

### DIFF
--- a/src/anyconfig_fortios_backend/fortios.py
+++ b/src/anyconfig_fortios_backend/fortios.py
@@ -53,7 +53,7 @@ EDIT_START_RE = re.compile(r"^(\s*)"
                            r"$")
 EDIT_END_RE = re.compile(r"^\s*next$")
 
-SET_OR_UNSET_LINE_RE = re.compile(r"^\s+"
+SET_OR_UNSET_LINE_RE = re.compile(r"^\s*"
                                   r"(set|unset)\s+"
                                   r"(\S+)\s*"
                                   r"(.+)*$")


### PR DESCRIPTION
When a configuration is exported from Fortimanager, there is no indentation.

Without this fix, the regexp would not match because it waits for at least a heading space.