### PR TITLE
fix to parse config files contain multiline text parameters correctly.

### DIFF
--- a/tests/res/multiline_parameter_10.json
+++ b/tests/res/multiline_parameter_10.json
@@ -1,0 +1,1 @@
+{"configs": [{"config": "foo", "edits": [{"edit": "123", "comments": "multi line\ntext which does not parse\ncorrectly"}]}]}

--- a/tests/res/multiline_parameter_10.txt
+++ b/tests/res/multiline_parameter_10.txt
@@ -1,0 +1,7 @@
+config foo
+  edit 123
+    set comments "multi line
+text which does not parse
+correctly"
+  next
+end

--- a/tests/test_fortios.py
+++ b/tests/test_fortios.py
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: MIT
 #
 # pylint: disable=missing-docstring,invalid-name,too-few-public-methods
+# pylint: disable=protected-access
+import pytest
+
 import anyconfig
 import anyconfig.ioinfo
 
@@ -13,6 +16,36 @@ import tests.constants
 
 
 _CNF_FILES = [str(p) for p in tests.constants.CNF_FILES]
+
+
+@pytest.mark.parametrize(
+    ("line", "exp"),
+    (("", None),
+     ('set service "HTTP" "PING" "TRACEROUTE""\n', None),
+     ('set foo "bar\n',
+      {"type": "set", "name": "foo", "values": ["bar\n"]}),
+     ('set foo "bar baz \n',
+      {"type": "set", "name": "foo", "values": ["bar baz \n"]}),
+     ('   set foo "bar" "baz\n',
+      {"type": "set", "name": "foo", "values": ["bar", "baz\n"]}
+      ),
+     ),
+)
+def test__process_set_multiline_value_start(line, exp):
+    res = F._process_set_with_multiline_value_start(line, container=dict)
+    assert res == exp
+
+
+@pytest.mark.parametrize(
+    ("line", "exp"),
+    (("", None),
+     ('"\n', ''),
+     ('foo "\n', 'foo '),
+     ),
+)
+def test__process_set_multiline_value_end(line, exp):
+    res = F._process_set_multiline_value_end(line)
+    assert res == exp
 
 
 def test_load(tmp_path):

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}/src
 commands =
-    pytest
+    pytest {posargs}
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
fix for #4 